### PR TITLE
 [ch32097] Countries dropdown doesn't go to item that starts with the pressed letter

### DIFF
--- a/src_ts/components/app-shell/header/countries-dropdown.ts
+++ b/src_ts/components/app-shell/header/countries-dropdown.ts
@@ -36,7 +36,7 @@ export class CountriesDropdown extends connect(store)(LitElement) {
         option-value="id"
         trigger-value-change-event
         @etools-selected-item-changed="${this.countrySelected}"
-        shown-options-limit="250"
+        .shownOptionsLimit="${250}"
         ?hidden="${!this.countrySelectorVisible}"
         hide-search
         .autoWidth="${true}"


### PR DESCRIPTION
 [ch32097] Countries dropdown doesn't go to item that starts with the pressed letter